### PR TITLE
Feat : 조회수 기반 랭킹조회 및 어뷰징 검증 기능 추가

### DIFF
--- a/src/main/java/me/yeon/freship/common/config/RedisConfig.java
+++ b/src/main/java/me/yeon/freship/common/config/RedisConfig.java
@@ -50,7 +50,7 @@ public class RedisConfig {
 
         // 캐시 이름별로 직렬화 방식 지정
         Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
-        cacheConfigurations.put("getRanks", objectCacheConfig);
+        cacheConfigurations.put("rank", objectCacheConfig);
         cacheConfigurations.put("search", responseCacheConfig);
 
         return RedisCacheManager

--- a/src/main/java/me/yeon/freship/common/domain/constant/ErrorCode.java
+++ b/src/main/java/me/yeon/freship/common/domain/constant/ErrorCode.java
@@ -26,6 +26,10 @@ public enum ErrorCode {
     NOT_STORE_OWNER(HttpStatus.FORBIDDEN, "STORE-2", "본인의 가게가 아닙니다."),
     BIZ_REG_NUM_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "STORE-3", "이미 존재하는 사업자등록번호입니다."),
 
+    // Product 에러코드
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "PRODUCT-1", "상품이 존재하지 않습니다."),
+    PRODUCT_NAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "PRODUCT-2", "중복된 상품명입니다."),
+
     EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "EXCEPTION", "알 수 없는 에러입니다.");
 
     private final HttpStatus status;

--- a/src/main/java/me/yeon/freship/common/utils/RedisUtils.java
+++ b/src/main/java/me/yeon/freship/common/utils/RedisUtils.java
@@ -6,14 +6,16 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
 public class RedisUtils {
 
-    private final RedisTemplate<String, String> redisTemplate;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     // 사용자 검색 기록 저장 (동일한 검색어 중복 방지)
     public void saveSearchHistory(Long userId, String searchKeyword) {
@@ -31,8 +33,52 @@ public class RedisUtils {
 
     // 인기 검색어 조회 (상위 10개)
     public List<String> getTopSearchKeywords() {
-        Set<String> popularSearch = redisTemplate.opsForZSet().reverseRange("rank", 0, 9);
+        Set<String> popularSearch = redisTemplate.opsForZSet()
+                .reverseRange("rank", 0, 9)
+                .stream()
+                .map(Object::toString)
+                .collect(Collectors.toSet());
         return popularSearch != null ? new ArrayList<>(popularSearch) : new ArrayList<>();
+    }
+
+    public void setReadCount(Long id){
+        redisTemplate.opsForZSet().add("product:readCount", "product:" + id, 1);
+    }
+
+    public Long getReadCount(Long productId){
+        return redisTemplate.opsForZSet().score("product:readCount", "product:" + productId).longValue();
+    }
+
+    public Long addReadCount(Long productId){
+        return redisTemplate.opsForZSet().incrementScore("product:readCount", "product:" + productId, 1).longValue();
+    }
+
+    public boolean notExistsReadCount(Long productId){
+        // 값이 존재하지 않는다면 null 반환
+        Double currentReadCount = redisTemplate.opsForZSet().score("product:readCount", "product:" + productId);
+        return currentReadCount == null;
+    }
+
+    // 조회수 상위 10개의 상품 id 리스트 조회
+    public List<Long> findProductIds() {
+        Set<Object> objectSet = redisTemplate.opsForZSet().reverseRange("product:readCount",0, 9);
+        if (objectSet == null) {
+            return Collections.emptyList();
+        }
+
+        //"product:7" -> ["product", "7"] -> ["7"]로 변환
+        List<Long> productIdList = new ArrayList<>();
+        for (Object o : objectSet) {
+            String value = (String) o;
+            String[] parts = value.split(":");
+            productIdList.add(Long.parseLong(parts[1]));
+        }
+        return productIdList;
+    }
+
+    public Boolean isNotViewed (Long productId, Long userId) {
+        Boolean isNotViewed = redisTemplate.opsForValue().setIfAbsent("product:" + productId + ":user:" + userId, "viewed");
+        return isNotViewed;
     }
 
     // 자정에 캐시 리셋
@@ -54,5 +100,15 @@ public class RedisUtils {
         if (Boolean.TRUE.equals(redisTemplate.hasKey("rank"))) {
             redisTemplate.opsForZSet().removeRange("rank", 0, -1);
         }
+
+        Set<String> visitorKeys = redisTemplate.keys("product*");
+        if (visitorKeys != null && !visitorKeys.isEmpty()) {
+            redisTemplate.delete(visitorKeys);
+        }
+
+        if (Boolean.TRUE.equals(redisTemplate.hasKey("product:readCount"))) {
+            redisTemplate.opsForZSet().removeRange("product:readCount", 0, -1);
+        }
     }
+
 }

--- a/src/main/java/me/yeon/freship/product/controller/ProductControllerV2.java
+++ b/src/main/java/me/yeon/freship/product/controller/ProductControllerV2.java
@@ -3,14 +3,13 @@ package me.yeon.freship.product.controller;
 import lombok.RequiredArgsConstructor;
 import me.yeon.freship.common.domain.Response;
 import me.yeon.freship.member.domain.AuthMember;
+import me.yeon.freship.product.domain.ProductRankResponse;
+import me.yeon.freship.product.domain.ProductReadCountResponse;
 import me.yeon.freship.product.domain.ProductSearchResponse;
 import me.yeon.freship.product.service.ProductService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -39,4 +38,20 @@ public class ProductControllerV2 {
         List<String> keywords = productService.findProductsByPopularSearch();
         return ResponseEntity.ok().body(Response.of(keywords));
     }
+
+    // 캐시에 조회수를 저장한 단건 상품 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<Response<ProductReadCountResponse>> findProductWithReadCount(@AuthenticationPrincipal AuthMember authMember,
+                                                                                       @PathVariable Long id){
+        ProductReadCountResponse product = productService.findProductWithReadCount(id, authMember.getId());
+        return ResponseEntity.ok().body(Response.of(product));
+    }
+
+    // 조회수 기준 상위 10개의 상품 리스트 조회
+    @GetMapping("/ranking/read-count")
+    public ResponseEntity<Response<List<ProductRankResponse>>> findProductsByReadCount(){
+        List<ProductRankResponse> products = productService.findProductsByReadCount();
+        return ResponseEntity.ok().body(Response.of(products));
+    }
+
 }

--- a/src/main/java/me/yeon/freship/product/domain/ProductRankResponse.java
+++ b/src/main/java/me/yeon/freship/product/domain/ProductRankResponse.java
@@ -1,0 +1,57 @@
+package me.yeon.freship.product.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class ProductRankResponse {
+
+    private final Long id;
+    private final Long rank;
+    private final String name;
+    private final Integer quantity;
+    private final Status status;
+    private final Category category;
+    private final Integer price;
+    private final String imgUrl;
+    private final String description;
+
+    @Builder
+    public ProductRankResponse(Long id, Long rank, String name, Integer quantity,
+                               Status status, Category category, Integer price, String imgUrl, String description) {
+        this.id = id;
+        this.rank = rank;
+        this.name = name;
+        this.quantity = quantity;
+        this.status = status;
+        this.category = category;
+        this.price = price;
+        this.imgUrl = imgUrl;
+        this.description = description;
+    }
+
+    public static List<ProductRankResponse> toProductRankResponseList(List<Product> products){
+        List<ProductRankResponse> readCountResponses = new ArrayList<>();
+        Long rank = 1L;
+        for (Product product : products) {
+            ProductRankResponse productReadCountResponse = ProductRankResponse.builder()
+                    .id(product.getId())
+                    .rank(rank++)
+                    .name(product.getName())
+                    .quantity(product.getQuantity())
+                    .category(product.getCategory())
+                    .price(product.getPrice())
+                    .status(product.getStatus())
+                    .price(product.getPrice())
+                    .imgUrl(product.getImgUrl())
+                    .description(product.getDescription())
+                    .build();
+
+            readCountResponses.add(productReadCountResponse);
+        }
+        return readCountResponses;
+    }
+}

--- a/src/main/java/me/yeon/freship/product/domain/ProductReadCountResponse.java
+++ b/src/main/java/me/yeon/freship/product/domain/ProductReadCountResponse.java
@@ -1,0 +1,34 @@
+package me.yeon.freship.product.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ProductReadCountResponse {
+
+    private final Long id;
+    private final Long readCount;
+    private final String name;
+    private final Integer quantity;
+    private final Status status;
+    private final Category category;
+    private final Integer price;
+    private final String imgUrl;
+    private final String description;
+
+    @Builder
+    public ProductReadCountResponse(Long id, Long readCount, String name, Integer quantity, Status status,
+                                    Category category, Integer price, String imgUrl, String description) {
+        this.id = id;
+        this.readCount = readCount;
+        this.name = name;
+        this.quantity = quantity;
+        this.status = status;
+        this.category = category;
+        this.price = price;
+        this.imgUrl = imgUrl;
+        this.description = description;
+    }
+
+}
+

--- a/src/main/java/me/yeon/freship/product/infrastructure/ProductRepository.java
+++ b/src/main/java/me/yeon/freship/product/infrastructure/ProductRepository.java
@@ -2,7 +2,12 @@ package me.yeon.freship.product.infrastructure;
 
 import me.yeon.freship.product.domain.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 
 public interface ProductRepository extends JpaRepository<Product, Long>, ProductRepositoryCustom {
+    @Query("SELECT p FROM Product p WHERE p.id in :productIds")
+    List<Product> findProductsByRank(List<Long> productIds);
 }

--- a/src/main/java/me/yeon/freship/product/service/ProductService.java
+++ b/src/main/java/me/yeon/freship/product/service/ProductService.java
@@ -7,6 +7,8 @@ import me.yeon.freship.common.exception.ClientException;
 import me.yeon.freship.common.utils.RedisUtils;
 import me.yeon.freship.member.infrastructure.MemberRepository;
 import me.yeon.freship.product.domain.Product;
+import me.yeon.freship.product.domain.ProductRankResponse;
+import me.yeon.freship.product.domain.ProductReadCountResponse;
 import me.yeon.freship.product.domain.ProductSearchResponse;
 import me.yeon.freship.product.infrastructure.ProductRepository;
 import org.springframework.cache.annotation.Cacheable;
@@ -15,7 +17,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
+
+import static me.yeon.freship.common.domain.constant.ErrorCode.PRODUCT_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -55,6 +60,59 @@ public class ProductService {
                 .stream()
                 .map(product -> ProductSearchResponse.fromEntity(product, pageInfo))
                 .toList();
+    }
+
+    // 캐시에 조회수를 저장한 단건 상품 조회
+    @Transactional
+    public ProductReadCountResponse findProductWithReadCount(Long id, Long userId) {
+        Product product = productRepository.findById(id).orElseThrow(() -> new ClientException(PRODUCT_NOT_FOUND));
+        Long readCount = findReadCount(product.getId(), userId);
+        ProductReadCountResponse productReadCountResponse =
+                ProductReadCountResponse.builder()
+                        .id(product.getId())
+                        .readCount(readCount)
+                        .name(product.getName())
+                        .quantity(product.getQuantity())
+                        .category(product.getCategory())
+                        .price(product.getPrice())
+                        .status(product.getStatus())
+                        .price(product.getPrice())
+                        .imgUrl(product.getImgUrl())
+                        .description(product.getDescription())
+                        .build();
+        return productReadCountResponse;
+    }
+
+    // 어뷰징 검증, 24시간 이내에 방문했다면 기존 조회수 조회, 아니라면 조회수 증가
+    public Long findReadCount(Long productId, Long userId) {
+        Boolean isNotViewed = redisUtils.isNotViewed(productId, userId);
+        if (Boolean.TRUE.equals(isNotViewed)) {
+            return addReadCount(productId);
+        }
+        return redisUtils.getReadCount(productId);
+    }
+
+    // 조회수가 없는 경우엔 1로 초기화, 존재하는 경우엔 조회수를 1만큼 증가
+    public Long addReadCount(Long productId) {
+        if (redisUtils.notExistsReadCount(productId)){
+            redisUtils.setReadCount(productId);
+            return 1L;
+        }
+        return redisUtils.addReadCount(productId);
+    }
+
+    // 조회수 기준 상위 10개의 상품 리스트 조회하기
+    @Transactional(readOnly = true)
+    @Cacheable(cacheNames = "rank", key = "'products:rank'", cacheManager = "productCacheManager")
+    public List<ProductRankResponse> findProductsByReadCount() {
+        List<Long> idList = redisUtils.findProductIds();
+        List<Product> products = productRepository.findProductsByRank(idList);
+
+        // 순위별로 정렬
+        products.sort(Comparator.comparingInt(p -> idList.indexOf(p.getId())));
+
+        List<ProductRankResponse> readCountResponses = ProductRankResponse.toProductRankResponseList(products);
+        return readCountResponses;
     }
 
     private PageInfo getPageInfo(String productName, int pageNum, int pageSize) {

--- a/src/test/java/me/yeon/freship/common/utils/RedisUtilsTest.java
+++ b/src/test/java/me/yeon/freship/common/utils/RedisUtilsTest.java
@@ -1,0 +1,151 @@
+package me.yeon.freship.common.utils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.List;
+
+import static java.lang.Boolean.TRUE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+public class RedisUtilsTest {
+
+    @Autowired
+    private RedisUtils redisUtils;
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @AfterEach
+    public void clear() {
+        redisTemplate.delete("product:readCount");
+    }
+
+    @Test
+    public void 상품_조회수가_1로_저장된다() {
+        // given
+        String setKey = "product:readCount";
+        Long productId = 1L;
+
+        // when
+        redisUtils.setReadCount(productId);
+
+        // then
+        Double score = redisTemplate.opsForZSet().score(setKey, "product:" + productId);
+        assertThat(score).isNotNull();
+        assertThat(score).isEqualTo(1.0);
+    }
+
+    @Test
+    public void 상품_조회수를_1만큼_증가한다() {
+        // given
+        String setKey = "product:readCount";
+        Long productId = 1L;
+        redisUtils.setReadCount(productId);
+
+        // when
+        redisUtils.addReadCount(productId);
+
+        // then
+        Double score = redisTemplate.opsForZSet().score(setKey, "product:" + productId);
+        assertThat(score).isNotNull();
+        assertThat(score).isEqualTo(2.0);
+    }
+
+    @Test
+    public void 상품의_조회수_데이터의_존재여부를_확인한다() {
+        // given
+        Long productId = 1L;
+
+        // when
+        Boolean isNotExist = redisUtils.notExistsReadCount(productId);
+
+        // then
+        assertThat(isNotExist).isNotNull();
+        assertThat(isNotExist).isEqualTo(true);
+    }
+
+    @Test
+    public void 조회수_상위_10개의_상품ID_리스트를_조회한다() {
+        // given
+        String setKey = "product:readCount";
+        Long top1readCountId = 9L;
+        Long top2readCountId = 0L;
+        for (Long i = 0L; i < 20; i++) {
+            redisUtils.setReadCount(i);
+        }
+        for (Long i = 0L; i < 10; i++) {
+            for (Long j = 0L; j <= i; j++) {
+                redisUtils.addReadCount(i);
+            }
+        }
+
+        // when
+        List<Long> productIdList = redisUtils.findProductIds();
+
+        // then
+        assertThat(productIdList).isNotNull();
+        assertThat(productIdList.get(0)).isEqualTo(top1readCountId);
+        assertThat(productIdList.get(9)).isEqualTo(top2readCountId);
+    }
+
+    @Test
+    public void 조회수_상위_10개의_상품ID가_Redis에_존재하지_않으면_emptyList를_반환한다() {
+        // given & when
+        List<Long> productIdList = redisUtils.findProductIds();
+
+        // then
+        assertThat(productIdList).isNotNull();
+        assertThat(productIdList.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void 사용자가_한_번도_해당_상품을_조회하지_않았다면_TRUE를_반환한다() {
+        // given
+        Long productId = 1L;
+        Long userId = 1L;
+
+        // when
+        Boolean isNotViewed = redisUtils.isNotViewed(productId, userId);
+
+        // then
+        assertThat(isNotViewed).isNotNull();
+        assertThat(isNotViewed).isEqualTo(TRUE);
+    }
+
+    @Test
+    public void Redis에_있는_모든_데이터를_삭제한다() {
+        // given
+        String setKey = "product:readCount";
+        Long productId = 1L;
+        redisUtils.setReadCount(productId);
+
+        // when
+        redisUtils.clearCache();
+        Double score = redisTemplate.opsForZSet().score(setKey, "product:" + productId);
+
+        // then
+        assertThat(score).isNull();
+    }
+
+    @Test
+    public void 상품의_조회수를_조회한다() {
+        // given
+        String setKey = "product:readCount";
+        Long productId = 1L;
+        redisUtils.setReadCount(productId);
+
+        // when
+        Long readCount = redisUtils.getReadCount(productId);
+
+        // then
+        assertThat(readCount).isNotNull();
+        assertThat(readCount).isEqualTo(1L);
+    }
+
+}

--- a/src/test/java/me/yeon/freship/product/service/ProductServiceTest.java
+++ b/src/test/java/me/yeon/freship/product/service/ProductServiceTest.java
@@ -4,6 +4,8 @@ import me.yeon.freship.common.utils.RedisUtils;
 import me.yeon.freship.member.domain.Member;
 import me.yeon.freship.member.infrastructure.MemberRepository;
 import me.yeon.freship.product.domain.Product;
+import me.yeon.freship.product.domain.ProductRankResponse;
+import me.yeon.freship.product.domain.ProductReadCountResponse;
 import me.yeon.freship.product.domain.ProductSearchResponse;
 import me.yeon.freship.product.infrastructure.ProductRepository;
 import org.junit.jupiter.api.Test;
@@ -15,16 +17,22 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static me.yeon.freship.product.domain.Category.SNACKS;
+import static me.yeon.freship.product.domain.Status.ON_SALE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class ProductServiceTest {
@@ -97,5 +105,124 @@ public class ProductServiceTest {
 
         assertNotNull(result);
         assertEquals(2, result.size());
+    }
+
+    @Test
+    public void 조회수를_포함하여_상품_상세정보를_조회한다() {
+        // given
+        Long productId = 1L;
+        Long userId = 1L;
+
+        Product product = new Product("포카칩", 5, ON_SALE, SNACKS, 3000,
+                "https://example.com/images/포카칩.jpg", "바삭바삭 맛이 좋은 감자칩입니다");
+        ReflectionTestUtils.setField(product, "id", productId);
+        when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+        when(productService.findReadCount(productId, userId)).thenReturn(10L);
+
+        // when
+        ProductReadCountResponse response = productService.findProductWithReadCount(productId, userId);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getId()).isEqualTo(product.getId());
+        assertThat(response.getReadCount()).isEqualTo(10L);
+        assertThat(response.getName()).isEqualTo(product.getName());
+        assertThat(response.getQuantity()).isEqualTo(product.getQuantity());
+        assertThat(response.getCategory()).isEqualTo(product.getCategory());
+        assertThat(response.getPrice()).isEqualTo(product.getPrice());
+        assertThat(response.getStatus()).isEqualTo(product.getStatus());
+        assertThat(response.getImgUrl()).isEqualTo(product.getImgUrl());
+        assertThat(response.getDescription()).isEqualTo(product.getDescription());
+    }
+
+    @Test
+    public void 상품의_조회수가_없는_경우_상품의_조회수를_1로_세팅해준다() {
+        // given
+        Long productId = 1L;
+        String setKey = "product:readCount";
+
+        when(redisUtils.notExistsReadCount(productId)).thenReturn(true);
+
+        // when
+        Long readCount = productService.addReadCount(productId);
+
+        // then
+        assertThat(readCount).isNotNull();
+        assertThat(readCount).isEqualTo(1L);
+    }
+
+    @Test
+    public void 상품의_조회수가_존재하는_경우_상품의_조회수를_1만큼_증가한다() {
+        // given
+        Long productId = 1L;
+        String setKey = "product:readCount";
+
+        redisUtils.setReadCount(productId);
+        Long readCount = redisUtils.getReadCount(productId);
+        when(redisUtils.notExistsReadCount(productId)).thenReturn(false);
+        when(redisUtils.addReadCount(productId)).thenReturn(readCount + 1L);
+
+        // when
+        Long addedReadCount = productService.addReadCount(productId);
+
+        // then
+        assertThat(addedReadCount).isEqualTo(readCount + 1L);
+    }
+
+    @Test
+    public void 하루동안_방문한_적이_없는_상품을_조회한_경우_조회수가_1_증가한다() {
+        // given
+        Long productId = 1L;
+        Long userId = 1L;
+
+        when(redisUtils.isNotViewed(productId, userId)).thenReturn(true);
+        when(redisUtils.notExistsReadCount(productId)).thenReturn(true);
+
+        // when
+        Long addedCount = productService.findReadCount(productId, userId);
+
+        // then
+        assertThat(addedCount).isNotNull();
+        assertThat(addedCount).isEqualTo(1L);
+    }
+
+    @Test
+    public void 조회수_기준_상위_10개의_상품_리스트를_순위를_포함하여_조회한다() {
+        // given
+        List<Long> topProductIds = List.of(10L, 5L, 20L, 15L, 1L);
+
+        Product rank1product = new Product("포카칩", 5, ON_SALE, SNACKS, 3000,
+                "https://example.com/images/포카칩.jpg", "바삭바삭 맛이 좋은 감자칩입니다");
+        ReflectionTestUtils.setField(rank1product, "id", 10L);
+        Product rank2product = new Product("수미칩", 5, ON_SALE, SNACKS, 3000,
+                "https://example.com/images/수미칩.jpg", "향과 맛이 좋은 감자칩입니다");
+        ReflectionTestUtils.setField(rank2product, "id", 5L);
+        Product rank3product = new Product("새우칩", 5, ON_SALE, SNACKS, 3000,
+                "https://example.com/images/새우칩.jpg", "짭짤한 맛이 좋은 새우칩입니다");
+        ReflectionTestUtils.setField(rank3product, "id", 20L);
+        Product rank4product = new Product("사과칩", 5, ON_SALE, SNACKS, 3000,
+                "https://example.com/images/사과칩.jpg", "달달한 맛이 좋은 사과칩입니다");
+        ReflectionTestUtils.setField(rank4product, "id", 15L);
+        Product rank5product = new Product("키위칩", 5, ON_SALE, SNACKS, 3000,
+                "https://example.com/images/키위칩.jpg", "향긋한 맛이 좋은 키위칩입니다");
+        ReflectionTestUtils.setField(rank5product, "id", 1L);
+        List<Product> products = new ArrayList<>();
+        products.add(rank1product);
+        products.add(rank2product);
+        products.add(rank3product);
+        products.add(rank4product);
+        products.add(rank5product);
+
+
+        when(redisUtils.findProductIds()).thenReturn(topProductIds);
+        when(productRepository.findProductsByRank(topProductIds)).thenReturn(products);
+
+        // when
+        List<ProductRankResponse> result = productService.findProductsByReadCount();
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.get(0).getId()).isEqualTo(rank1product.getId());
+        assertThat(result.get(0).getName()).isEqualTo(rank1product.getName());
     }
 }


### PR DESCRIPTION
- 상품 조회 시 해당 게시글의 조회수를 카운팅
- 어뷰징 방지
- 조회수를 기준으로 상위 10개의 상품정보를 랭킹을 포함하여 조회

처음에 제 feat/kyn/v1/rank에서 **rebase**를 진행하려고 했으나 모종의 이유로 옛날 커밋과 꼬여서 새로  feat/rank 브랜치를 최신화된 dev에서 따온 후에 제 변경사항을 추가했습니다

feat/rank인 현재 리포지토리는 캐싱 부분이 모두 합쳐지고 적용됐습니다!